### PR TITLE
prevent user from submitting empty field on basic uploader

### DIFF
--- a/backend/app/server/proxy/src/main/mona-web/src/app/components/upload/basic-uploader.component.ts
+++ b/backend/app/server/proxy/src/main/mona-web/src/app/components/upload/basic-uploader.component.ts
@@ -44,6 +44,7 @@ export class BasicUploaderComponent implements OnInit{
     filenames;
     pastedSpectrum;
     fileUpload;
+    metaDataErrors;
 
     faCloudUpload = faCloudUploadAlt;
     faSpinner = faSpinner;
@@ -67,6 +68,7 @@ export class BasicUploaderComponent implements OnInit{
         this.page = 0;
         this.fileHasMultipleSpectra = false;
         this.showIonTable = true;
+        this.metaDataErrors = [];
 
         /**
          * Sort order for the ion table - default m/z ascending
@@ -645,5 +647,19 @@ export class BasicUploaderComponent implements OnInit{
         return new Promise((resolve) => {
            resolve(this.filterPipe.transform(this.tags, query));
         });
+    }
+
+    validateMetadata() {
+      const emptyPieces = this.currentSpectrum.meta.filter((x) => {
+        return x.name.replace(/\s+/g, '') === '' || x.value.replace(/\s+/g, '') === '';
+      });
+
+      if (emptyPieces.length > 0) {
+        this.metaDataErrors = [];
+        this.metaDataErrors.push('One or more metadata entries are missing data, please provide entries in both fields of remove entry with minus button');
+      } else {
+        this.metaDataErrors = [];
+        this.nextPage();
+      }
     }
 }

--- a/backend/app/server/proxy/src/main/mona-web/src/app/views/spectra/query/keywordSearchForm.html
+++ b/backend/app/server/proxy/src/main/mona-web/src/app/views/spectra/query/keywordSearchForm.html
@@ -153,7 +153,7 @@
         </div>
     </div>
 
-    <div class="row mb-2" *ngIf="queryTags.length > 0">
+    <div class="row mb-2">
         <div class="col-md-12 h-auto">
             <ngb-accordion #acc activeIds="additionalTags">
                 <ngb-panel id="additionalTags" title="Add Additional Tags to Query">

--- a/backend/app/server/proxy/src/main/mona-web/src/app/views/spectra/upload/basicUploader.html
+++ b/backend/app/server/proxy/src/main/mona-web/src/app/views/spectra/upload/basicUploader.html
@@ -517,17 +517,21 @@
                 </div>
                 <br />
 
+                <div *ngIf="metaDataErrors.length > 0">
+                  <h3 class="text-danger">{{metaDataErrors[0]}}</h3>
+                </div>
+
                 <div id="metadata_editor" style="margin-top: 10px;">
                     <div *ngFor="let meta of currentSpectrum.meta; index as i">
                       <div class="row">
                         <div class="col-sm-5 form-group" [ngClass]="{'has-error': !meta.name && meta.name !== ''}">
-                          <input type="text"
+                          <input required type="text"
                                  [(ngModel)]="meta.name"
                                  placeholder="Metadata Name"
                                  class="form-control" />
                         </div>
                         <div class="col-sm-5 form-group">
-                          <input type="text"
+                          <input required type="text"
                                  [(ngModel)]="meta.value"
                                  [disabled]="!meta.name || meta.name === ''"
                                  placeholder="Metadata Value"
@@ -555,7 +559,7 @@
                 </div>
                 <div class="navbar-collapse collapse w-100 order-3 dual-collapse2">
                   <ul class="navbar-nav ml-auto">
-                    <li class="next"><button class="fakeRef" (click)="nextPage()">Next <fa-icon [icon]="faArrowRight"></fa-icon></button></li>
+                    <li class="next"><button class="fakeRef" (click)="validateMetadata()">Next <fa-icon [icon]="faArrowRight"></fa-icon></button></li>
                   </ul>
                 </div>
               </nav>


### PR DESCRIPTION
Added more prevention methods so users can't add empty fields that break the backend (this seems to happen when bootstrap syncs overnight with elasticsearch. Will investigate further but we can prevent this on the frontend side).