### PR TITLE
Condense Space Usage on Similarity Service

### DIFF
--- a/backend/services/similarity/src/main/scala/edu/ucdavis/fiehnlab/mona/core/similarity/math/binning/BinByRoundingMethod.scala
+++ b/backend/services/similarity/src/main/scala/edu/ucdavis/fiehnlab/mona/core/similarity/math/binning/BinByRoundingMethod.scala
@@ -26,7 +26,7 @@ class BinByRoundingMethod extends BinningMethod {
     // Collect bins as ions
     val ions: Array[Ion] = binnedIons.keys.map(x => Ion(x, binnedIons(x))).toArray.sortBy(_.mz)
 
-    new SimpleSpectrum(spectrum.id, ions, spectrum.precursorMZ, spectrum.tags, spectrum.public, spectrum.compound) with BinnedSimpleSpectrum
+    new SimpleSpectrum(spectrum.id, ions, spectrum.precursorMZ, spectrum.tags, spectrum.public, spectrum.adducts) with BinnedSimpleSpectrum
   }
 
   override def binIon(ion: Ion): Ion = SpectrumUtils.roundMZ(ion)

--- a/backend/services/similarity/src/main/scala/edu/ucdavis/fiehnlab/mona/core/similarity/run/Calculate.scala
+++ b/backend/services/similarity/src/main/scala/edu/ucdavis/fiehnlab/mona/core/similarity/run/Calculate.scala
@@ -37,27 +37,11 @@ trait Calculate extends LazyLogging {
     Math.abs(unknownPrecursorMZ - referencePrecursorMZ)
   }
 
-  def findAdductMatch(unknownPrecursorMz: Double, precursorToleranceDa: Double, knownCompounds: Array[Compound]): Boolean = {
-    val biologicalCompound: Compound =
-      if (knownCompounds.exists(_.kind == "biological")) {
-        knownCompounds.find(_.kind == "biological").head
-      } else if (knownCompounds.nonEmpty) {
-        knownCompounds.head
-      } else {
-        null
-      }
-
-    if (biologicalCompound == null) {
-      logger.debug(s"Compound not on spectra")
+  def findAdductMatch(unknownPrecursorMz: Double, precursorToleranceDa: Double, theoreticalAdducts: Array[Double]): Boolean = {
+    if(theoreticalAdducts.length == 0) {
       false
     } else {
-      val theoreticalAdducts: Array[MetaData] = biologicalCompound.metaData.filter(x => x.category == "theoretical adduct")
-      if(theoreticalAdducts.length == 0) {
-        false
-      } else {
-        theoreticalAdducts.exists(x => calculateAbsolute(unknownPrecursorMz, x.value.asInstanceOf[Double]) <= precursorToleranceDa)
-      }
-
+      theoreticalAdducts.exists(x => calculateAbsolute(unknownPrecursorMz, x) <= precursorToleranceDa)
     }
   }
 }

--- a/backend/services/similarity/src/main/scala/edu/ucdavis/fiehnlab/mona/core/similarity/run/MultiThreadRunner.scala
+++ b/backend/services/similarity/src/main/scala/edu/ucdavis/fiehnlab/mona/core/similarity/run/MultiThreadRunner.scala
@@ -27,7 +27,7 @@ class MultiThreadRunner extends Calculate {
       else if(!removePrecursorIon && checkAllAdducts)  {
         library.par
           .filter(!_.precursorMZ.isNaN)
-          .filter(x => {findAdductMatch(unknown.precursorMZ, precursorToleranceDa, x.compound)})
+          .filter(x => {findAdductMatch(unknown.precursorMZ, precursorToleranceDa, x.adducts)})
           .map(spectrum => ComputationalResult(unknown, spectrum, algorithm.compute(unknown, spectrum, removePrecursorIon)))
           .filter(_.score >= threshold)
           .seq

--- a/backend/services/similarity/src/main/scala/edu/ucdavis/fiehnlab/mona/core/similarity/types/SpectrumTypes.scala
+++ b/backend/services/similarity/src/main/scala/edu/ucdavis/fiehnlab/mona/core/similarity/types/SpectrumTypes.scala
@@ -1,6 +1,5 @@
 package edu.ucdavis.fiehnlab.mona.core.similarity.types
 
-import edu.ucdavis.fiehnlab.mona.backend.core.domain.{Compound, MetaData}
 import edu.ucdavis.fiehnlab.mona.core.similarity.util.SpectrumUtils
 
 /**
@@ -29,7 +28,7 @@ case class Ion(mz: Double, intensity: Double) {
   * @param ions
   * @param public
   */
-class SimpleSpectrum(val id: String, val ions: Array[Ion], val precursorMZ: Double, val tags: Array[String], val public: Boolean, val compound: Array[Compound]) {
+class SimpleSpectrum(val id: String, val ions: Array[Ion], val precursorMZ: Double, val tags: Array[String], val public: Boolean, val adducts: Array[Double]) {
 
   /**
     * Constructors
@@ -43,19 +42,19 @@ class SimpleSpectrum(val id: String, val ions: Array[Ion], val precursorMZ: Doub
 
   def this(id: String, spectrumString: String, precursorMZ: Double, tags: Array[String]) = this(id, SpectrumUtils.stringToIons(spectrumString), precursorMZ, tags, true, Array())
 
-  def this(id: String, spectrumString: String, precursorMZ: Double, tags: Array[String], compound: Array[Compound]) = this(id, SpectrumUtils.stringToIons(spectrumString), precursorMZ, tags, true, compound)
+  def this(id: String, spectrumString: String, precursorMZ: Double, tags: Array[String], adducts: Array[Double]) = this(id, SpectrumUtils.stringToIons(spectrumString), precursorMZ, tags, true, adducts)
 
   def this(id: String, spectrumString: String, tags: Array[String]) = this(id, SpectrumUtils.stringToIons(spectrumString), -1, tags, true, Array())
 
-  def this(id: String, spectrumString: String, tags: Array[String], compound: Array[Compound]) = this(id, SpectrumUtils.stringToIons(spectrumString), -1, tags, true, compound)
+  def this(id: String, spectrumString: String, tags: Array[String], adducts: Array[Double]) = this(id, SpectrumUtils.stringToIons(spectrumString), -1, tags, true, adducts)
 
   def this(id: String, spectrumString: String) = this(id, SpectrumUtils.stringToIons(spectrumString), -1, Array(), true, Array())
 
   def this(id: String, spectrumString: String, precursorMZ: Double) = this(id, SpectrumUtils.stringToIons(spectrumString), precursorMZ, Array(), true, Array())
 
-  def this(id: String, spectrumString: String, precursorMZ: Double, compounds: Array[Compound]) = this(id, SpectrumUtils.stringToIons(spectrumString), precursorMZ, Array(), true, compounds)
+  def this(id: String, spectrumString: String, precursorMZ: Double, adducts: Array[Double]) = this(id, SpectrumUtils.stringToIons(spectrumString), precursorMZ, Array(), true, adducts)
 
-  def this(id: String, spectrumString: String, compounds: Array[Compound]) = this(id, SpectrumUtils.stringToIons(spectrumString), -1, Array(), true, compounds)
+  def this(id: String, spectrumString: String, adducts: Array[Double]) = this(id, SpectrumUtils.stringToIons(spectrumString), -1, Array(), true, adducts)
 
   def this(spectrum: StoredSpectrum) = this(spectrum.id, spectrum.spectrum)
 


### PR DESCRIPTION
The Calculate All Adducts feature required metaData from the Compound object in order to search for the adducts in the Similarity service. The consequence of adding the Compounds object was that it added a significant amount of data to the SimpleSpectrum objects that are stored in memory in the Similarity Service. This caused multiple java memory heap errors on large requests. To circumvent this problem, we specifically parse the Compound for Theoretical Adducts and store the results in an Array of Doubles. This should restore virtually restore the SimpleSpectrum objects to their original size and avoid java heap memories. No changes will be needed to the API requests or requests format.