### PR TITLE
BUGFIX: Remove Remaining Traces of Statistics Module from Persistence-Server

### DIFF
--- a/backend/core/rest/persistence-server/pom.xml
+++ b/backend/core/rest/persistence-server/pom.xml
@@ -35,11 +35,6 @@
         </dependency>
 
         <dependency>
-            <groupId>edu.ucdavis.fiehnlab.mona.backend.core</groupId>
-            <artifactId>statistics</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>edu.ucdavis.fiehnlab.splash</groupId>
             <artifactId>core</artifactId>
         </dependency>

--- a/backend/core/rest/persistence-server/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/core/persistence/rest/server/app/RestPersistenceServer.scala
+++ b/backend/core/rest/persistence-server/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/core/persistence/rest/server/app/RestPersistenceServer.scala
@@ -6,7 +6,6 @@ import edu.ucdavis.fiehnlab.mona.backend.core.domain.service.LoginService
 import edu.ucdavis.fiehnlab.mona.backend.core.persistence.postgresql.config.PostgresqlConfiguration
 import edu.ucdavis.fiehnlab.mona.backend.core.persistence.rest.server.config.RestServerConfig
 import edu.ucdavis.fiehnlab.mona.backend.core.persistence.rest.{EurekaClientConfig, SwaggerConfig}
-import edu.ucdavis.fiehnlab.mona.backend.core.statistics.config.StatisticsRepositoryConfig
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.context.annotation.{Bean, Import}
@@ -16,7 +15,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
   * Created by wohlgemuth on 3/28/16.
   */
 @SpringBootApplication(scanBasePackages = Array("edu.ucdavis.fiehnlab.mona.backend.core.persistence.postgresql"))
-@Import(Array(classOf[RestServerConfig], classOf[JWTAuthenticationConfig], classOf[SwaggerConfig], classOf[EurekaClientConfig], classOf[StatisticsRepositoryConfig], classOf[PostgresqlConfiguration]))
+@Import(Array(classOf[RestServerConfig], classOf[JWTAuthenticationConfig], classOf[SwaggerConfig], classOf[EurekaClientConfig], classOf[PostgresqlConfiguration]))
 @EnableScheduling
 class RestPersistenceServer {
 

--- a/backend/core/rest/persistence-server/src/test/scala/edu/ucdavis/fiehnlab/mona/backend/core/persistence/rest/server/config/EmbeddedRestServerConfig.scala
+++ b/backend/core/rest/persistence-server/src/test/scala/edu/ucdavis/fiehnlab/mona/backend/core/persistence/rest/server/config/EmbeddedRestServerConfig.scala
@@ -4,7 +4,6 @@ import com.typesafe.scalalogging.LazyLogging
 import edu.ucdavis.fiehnlab.mona.backend.core.auth.jwt.service.PostgresLoginService
 import edu.ucdavis.fiehnlab.mona.backend.core.domain.service.LoginService
 import edu.ucdavis.fiehnlab.mona.backend.core.persistence.postgresql.config.PostgresqlConfiguration
-import edu.ucdavis.fiehnlab.mona.backend.core.statistics.config.StatisticsRepositoryConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.context.annotation.{Bean, Configuration, Import}
 
@@ -26,5 +25,5 @@ class EmbeddedRestServerConfig extends LazyLogging {
 }
 
 @SpringBootApplication(scanBasePackageClasses = Array())
-@Import(Array(classOf[PostgresqlConfiguration], classOf[StatisticsRepositoryConfig]))
+@Import(Array(classOf[PostgresqlConfiguration])
 class TestConfig

--- a/backend/docker-compose-prod.yml
+++ b/backend/docker-compose-prod.yml
@@ -157,7 +157,7 @@ services:
         max-size: "100M"
 
   statistics:
-    image: public.ecr.aws/fiehnlab/mona-statistics-server:test
+    image: public.ecr.aws/fiehnlab/mona-statistics-server:prod
     depends_on:
       - webhooks
       - discovery

--- a/backend/services/download-scheduler/pom.xml
+++ b/backend/services/download-scheduler/pom.xml
@@ -39,10 +39,6 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>edu.ucdavis.fiehnlab.mona.backend.core</groupId>
-            <artifactId>statistics</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>edu.ucdavis.fiehnlab.mona.backend.services</groupId>

--- a/backend/services/download-scheduler/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/services/downloader/scheduler/service/StaticDownloadService.scala
+++ b/backend/services/download-scheduler/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/services/downloader/scheduler/service/StaticDownloadService.scala
@@ -7,7 +7,6 @@ import com.typesafe.scalalogging.LazyLogging
 import edu.ucdavis.fiehnlab.mona.backend.services.downloader.domain.StaticDownload
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 
 import scala.jdk.CollectionConverters._


### PR DESCRIPTION
Fixed an issue where the persistence-server was still generating statistics even with the introduction of a separate statistics-sever.