### PR TITLE
FIEHNLAB-2128/Update To Java 17, Fix Scheduling Issue, Move Logs to CloudWatch

### DIFF
--- a/backend/docker-compose-dev.yml
+++ b/backend/docker-compose-dev.yml
@@ -28,8 +28,11 @@ services:
       - postgresql-data:/var/lib/postgresql/data
       - ./postgresql-dev.conf:/etc/postgresql.conf
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-test-logs
+        awslogs-stream: postgres
 
   postgresql-hero:
     image: ankane/pghero
@@ -46,8 +49,11 @@ services:
       - "15672:15672"
       - "5672:5672"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-test-logs
+        awslogs-stream: rabbitmq
 
 
   #
@@ -68,8 +74,11 @@ services:
       - GIT_USER=${GIT_USER}
       - GIT_PASS=${GIT_PASS}
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-test-logs
+        awslogs-stream: discovery-service
 
   config-server:
     image: public.ecr.aws/fiehnlab/mona-config:test
@@ -83,8 +92,11 @@ services:
       - GIT_USER=${GIT_USER}
       - GIT_PASS=${GIT_PASS}
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-test-logs
+        awslogs-stream: config-service
 
 
   #
@@ -98,8 +110,11 @@ services:
       - config-server
     entrypoint: bash -c "./wait-for-it.sh config-server:1111 -t 3600 --strict -- java -Xmx2g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-test-logs
+        awslogs-stream: bootstrap-service
 #
 #  # Webhook support to notify external apis
   webhooks:
@@ -110,8 +125,11 @@ services:
       - config-server
     entrypoint: bash -c "./wait-for-it.sh config-server:1111 -t 3600 --strict -- java -Xmx2g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-test-logs
+        awslogs-stream: webhooks-service
 #
 #  # Scheduler for curation jobs
   curationScheduler:
@@ -123,8 +141,11 @@ services:
       - webhooks
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx2g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-test-logs
+        awslogs-stream: curation-scheduler-service
 
   #
   # Persistence server, which utilizes above services, and other dependent services
@@ -138,8 +159,11 @@ services:
       - discovery
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx4g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-test-logs
+        awslogs-stream: persistence-service
 
   statistics:
     image: public.ecr.aws/fiehnlab/mona-statistics-server:test
@@ -148,16 +172,22 @@ services:
       - discovery
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx4g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-test-logs
+        awslogs-stream: statistics-service
 
   # Main authentication service
   auth:
     image: public.ecr.aws/fiehnlab/mona-auth-server:test
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx2g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-test-logs
+        awslogs-stream: auth-service
 
   # MoNA similarity service
   similarity:
@@ -169,8 +199,11 @@ services:
       - discovery
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx3g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-test-logs
+        awslogs-stream: similarity-service
 
 
   #
@@ -188,8 +221,11 @@ services:
       - VIRTUAL_HOST='mona.fiehnlab.ucdavis.edu'
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xss4m -Xmx2g -XX:+UseParallelGC -XX:+UseCompressedOops -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-test-logs
+        awslogs-stream: proxy-service
 
   # Download service for scheduling and running download jobs
   downloader:
@@ -203,8 +239,11 @@ services:
     volumes:
       - downloader-data:/data
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-test-logs
+        awslogs-stream: downloader-service
 
   # Run scheduled curation tasks
   curationRunner:
@@ -214,5 +253,8 @@ services:
       - webhooks
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx2g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-test-logs
+        awslogs-stream: curation-runner-service

--- a/backend/docker-compose-prod.yml
+++ b/backend/docker-compose-prod.yml
@@ -27,10 +27,12 @@ services:
     volumes:
       - postgresql-data:/var/lib/postgresql/data
       - ./postgresql-prod.conf:/etc/postgresql.conf
-
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-logs
+        awslogs-stream: postgres
 
 
   rabbitmq:
@@ -39,8 +41,11 @@ services:
       - "15672:15672"
       - "5672:5672"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-logs
+        awslogs-stream: rabbitmq
 
 
   #
@@ -60,8 +65,11 @@ services:
       - ./nginx_v2/config/mona.fiehnlab.ucdavis.edu.conf:/etc/nginx/conf.d/mona.fiehnlab.ucdavis.edu.conf
       - ./nginx_v2/config/massbank.us.conf:/etc/nginx/conf.d/massbank.us.conf
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-logs
+        awslogs-stream: nginx
 
 
   #
@@ -82,8 +90,11 @@ services:
       - GIT_USER=${GIT_USER}
       - GIT_PASS=${GIT_PASS}
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-logs
+        awslogs-stream: discovery-service
 
   config-server:
     image: public.ecr.aws/fiehnlab/mona-config:prod
@@ -97,8 +108,11 @@ services:
       - GIT_USER=${GIT_USER}
       - GIT_PASS=${GIT_PASS}
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-logs
+        awslogs-stream: config-service
 
 
   #
@@ -112,8 +126,11 @@ services:
       - config-server
     entrypoint: bash -c "./wait-for-it.sh config-server:1111 -t 3600 --strict -- java -Xmx4g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-logs
+        awslogs-stream: bootstrap-service
 
   # Webhook support to notify external apis
   webhooks:
@@ -124,8 +141,11 @@ services:
       - config-server
     entrypoint: bash -c "./wait-for-it.sh config-server:1111 -t 3600 --strict -- java -Xmx6g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-logs
+        awslogs-stream: webhooks-service
 
   #Scheduler for curation jobs
   curationScheduler:
@@ -137,8 +157,11 @@ services:
       - webhooks
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx8g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-logs
+        awslogs-stream: curation-scheduler-service
 
 
   #
@@ -153,8 +176,11 @@ services:
       - discovery
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx20g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-logs
+        awslogs-stream: persistence-service
 
   statistics:
     image: public.ecr.aws/fiehnlab/mona-statistics-server:prod
@@ -163,16 +189,22 @@ services:
       - discovery
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx20g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-logs
+        awslogs-stream: statistics-service
 
   # Main authentication service
   auth:
     image: public.ecr.aws/fiehnlab/mona-auth-server:prod
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx3g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-logs
+        awslogs-stream: auth-service
 
   # MoNA similarity service
   similarity:
@@ -184,8 +216,11 @@ services:
       - discovery
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx20g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-logs
+        awslogs-stream: similarity-service
 
   #
   # Proxy and additional standalone services
@@ -202,9 +237,11 @@ services:
       - VIRTUAL_HOST='mona.fiehnlab.ucdavis.edu'
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xss4m -Xmx4g -XX:+UseParallelGC -XX:+UseCompressedOops -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "10G"
-        max-file: "3"
+        awslogs-region: us-west-2
+        awslogs-group: mona-logs
+        awslogs-stream: proxy-service
 
   # Download service for scheduling and running download jobs
   downloader:
@@ -218,8 +255,11 @@ services:
     volumes:
       - downloader-data:/data
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-logs
+        awslogs-stream: downloader-service
 
   # Run scheduled curation tasks
   curationRunner:
@@ -229,5 +269,8 @@ services:
       - webhooks
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx8g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-logs
+        awslogs-stream: curation-runner-service

--- a/backend/docker-compose-uat.yml
+++ b/backend/docker-compose-uat.yml
@@ -28,8 +28,11 @@ services:
       - postgresql-data:/var/lib/postgresql/data
       - ./postgresql-uat.conf:/etc/postgresql.conf
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-dev-logs
+        awslogs-stream: postgres
 
   postgresql-hero:
     image: ankane/pghero
@@ -46,8 +49,11 @@ services:
       - "15672:15672"
       - "5672:5672"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-dev-logs
+        awslogs-stream: rabbitmq
 
 
   #
@@ -68,8 +74,11 @@ services:
       - GIT_USER=${GIT_USER}
       - GIT_PASS=${GIT_PASS}
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-dev-logs
+        awslogs-stream: discovery-service
 
   config-server:
     image: public.ecr.aws/fiehnlab/mona-config:test
@@ -83,8 +92,11 @@ services:
       - GIT_USER=${GIT_USER}
       - GIT_PASS=${GIT_PASS}
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-dev-logs
+        awslogs-stream: config-service
 
 
   #
@@ -98,8 +110,11 @@ services:
       - config-server
     entrypoint: bash -c "./wait-for-it.sh config-server:1111 -t 3600 --strict -- java -Xmx6g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-dev-logs
+        awslogs-stream: bootstrap-service
 
   # Webhook support to notify external apis
   webhooks:
@@ -110,8 +125,11 @@ services:
       - config-server
     entrypoint: bash -c "./wait-for-it.sh config-server:1111 -t 3600 --strict -- java -Xmx6g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-dev-logs
+        awslogs-stream: webhooks-service
 
   #Scheduler for curation jobs
   curationScheduler:
@@ -123,8 +141,11 @@ services:
       - webhooks
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx8g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-dev-logs
+        awslogs-stream: curation-scheduler-service
 
 
   #
@@ -141,8 +162,11 @@ services:
       - "1337:1337"
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx20g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-dev-logs
+        awslogs-stream: persistence-service
 
   statistics:
     image: public.ecr.aws/fiehnlab/mona-statistics-server:test
@@ -151,16 +175,22 @@ services:
       - discovery
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx20g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-dev-logs
+        awslogs-stream: statistics-service
 
   # Main authentication service
   auth:
     image: public.ecr.aws/fiehnlab/mona-auth-server:test
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx3g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-dev-logs
+        awslogs-stream: auth-service
 
   # MoNA similarity service
   similarity:
@@ -172,8 +202,11 @@ services:
       - discovery
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx20g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-dev-logs
+        awslogs-stream: similarity-service
 
   #
   # Proxy and additional standalone services
@@ -188,8 +221,12 @@ services:
       - webhooks
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xss4m -Xmx4g -XX:+UseParallelGC -XX:+UseCompressedOops -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-dev-logs
+        awslogs-stream: proxy-service
+
 
   # Download service for scheduling and running download jobs
   downloader:
@@ -203,8 +240,11 @@ services:
     volumes:
       - downloader-data:/data
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-dev-logs
+        awslogs-stream: downloader-service
 
   # Run scheduled curation tasks
   curationRunner:
@@ -214,5 +254,8 @@ services:
       - webhooks
     entrypoint: bash -c "./wait-for-it.sh webhooks:4444 -t 3600 --strict -- java -Xmx10g -XX:+UseParallelGC -Dspring.config.import=configserver:http://config-server:1111/ -Dspring.profiles.active=docker,prod -jar *.jar"
     logging:
+      driver: awslogs
       options:
-        max-size: "100M"
+        awslogs-region: us-west-2
+        awslogs-group: mona-dev-logs
+        awslogs-stream: curation-runner-service

--- a/backend/services/statistics-server/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/services/statistics/server/StatisticServer.scala
+++ b/backend/services/statistics-server/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/services/statistics/server/StatisticServer.scala
@@ -7,10 +7,11 @@ import edu.ucdavis.fiehnlab.mona.backend.core.persistence.rest.{EurekaClientConf
 import edu.ucdavis.fiehnlab.mona.backend.core.statistics.config.StatisticsRepositoryConfig
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.SpringApplication
-import org.springframework.boot.autoconfigure.{SpringBootApplication}
-import org.springframework.context.annotation.{Import}
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.annotation.Import
 import org.springframework.core.annotation.Order
 import org.springframework.http.HttpMethod
+import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.{EnableWebSecurity, WebSecurityConfigurerAdapter, WebSecurityCustomizer}
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -18,6 +19,7 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity
 
 @SpringBootApplication
 @EnableWebSecurity
+@EnableScheduling
 @Order(3)
 @Import(Array(classOf[JWTAuthenticationConfig], classOf[SwaggerConfig], classOf[EurekaClientConfig], classOf[StatisticsRepositoryConfig], classOf[PostgresqlConfiguration]))
 class StatisticServer extends WebSecurityConfigurerAdapter {

--- a/pom.xml
+++ b/pom.xml
@@ -18,12 +18,12 @@
     </parent>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <encoding>UTF-8</encoding>
         <scala.version>2.13</scala.version>
         <scala.minor.version>6</scala.minor.version>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <jackson.version>2.13.1</jackson.version>
     </properties>
 
@@ -620,7 +620,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
                         <plugin>
                             <groupId>net.alchim31.maven</groupId>
                             <artifactId>scala-maven-plugin</artifactId>
-                            <version>4.6.1</version>
+                            <version>4.7.0</version>
                         </plugin>
                     </plugins>
                 </pluginManagement>
@@ -210,7 +210,7 @@
                     <plugin>
                         <groupId>net.alchim31.maven</groupId>
                         <artifactId>scala-maven-plugin</artifactId>
-                        <version>4.6.1</version>
+                        <version>4.7.0</version>
                         <executions>
                             <execution>
                                 <id>scala-compile</id>
@@ -232,7 +232,12 @@
                             <scalaVersion>${scala.version}.${scala.minor.version}</scalaVersion>
                             <jvmArgs>
                                 <jvmArg>-Xms64m</jvmArg>
-                                <jvmArg>-Xmx2048m</jvmArg>
+                                <jvmArg>-Xmx8192m</jvmArg>
+                                <jvmArg>-XX:+UseParallelGC</jvmArg>
+                                <jvmArg>-XX:ReservedCodeCacheSize=2G</jvmArg>
+                                <jvmArg>-XX:+UseCodeCacheFlushing</jvmArg>
+                                <jvmArg>--add-opens=java.base/sun.nio.ch=ALL-UNNAMED</jvmArg>
+                                <jvmArg>--add-opens java.base/java.lang=ALL-UNNAMED</jvmArg>
                             </jvmArgs>
                         </configuration>
                     </plugin>
@@ -322,7 +327,7 @@
                         <plugin>
                             <groupId>net.alchim31.maven</groupId>
                             <artifactId>scala-maven-plugin</artifactId>
-                            <version>4.6.1</version>
+                            <version>4.7.0</version>
                         </plugin>
                     </plugins>
                 </pluginManagement>
@@ -348,7 +353,7 @@
                     <plugin>
                         <groupId>net.alchim31.maven</groupId>
                         <artifactId>scala-maven-plugin</artifactId>
-                        <version>4.6.1</version>
+                        <version>4.7.0</version>
                         <executions>
                             <execution>
                                 <id>scala-compile</id>
@@ -364,6 +369,8 @@
                             <jvmArgs>
                                 <jvmArg>-Xms64m</jvmArg>
                                 <jvmArg>-Xmx1024m</jvmArg>
+                                <jvmArg>-XX:+UseParallelGC</jvmArg>
+                                <jvmArg>-XX:ReservedCodeCacheSize=4G</jvmArg>
                             </jvmArgs>
                         </configuration>
                     </plugin>
@@ -460,7 +467,7 @@
 
             <properties>
                 <docker.registry>public.ecr.aws/fiehnlab</docker.registry>
-                <docker.baseImage>openjdk:8</docker.baseImage>
+                <docker.baseImage>amazoncorretto:17.0.6</docker.baseImage>
                 <docker.imagePrefix>mona</docker.imagePrefix>
                 <docker.imageName>${docker.imagePrefix}-${project.name}</docker.imageName>
                 <docker.imagePath>${docker.registry}/${docker.imageName}</docker.imagePath>


### PR DESCRIPTION
- Updated MoNA's Java version to 17 up from 1.8
- Fixed Issue where the Statistics weren't automatically generating everyday
- Now using AWS CloudWatch to store all of MoNA's logs for better search, metrics, and storage