### PR TITLE
3.1.0 Hotfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,10 @@ The `./scripts/generate_backup.sh` script is used to generate backups of the pos
    ```
 
 2. Using the built-in Maven tab in IntelliJ (right-hand side by default), run `mvn clean install` on the `backend` folder.
-- Or run `mvn clean test` from the terminal inside the `backend/` folder.
+
+OR
+
+2. From the terminal, run `mvn clean install -P '!docker'` inside the `backend/` folder. Ensure you are using Java 17.
 
 **Frontend tests:**
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MassBank of North America (MoNA)
 
-The MoNA application can be found at https://mona.fiehnlab.ucdavis.edu/ or https://massbank.us/
+The MoNA website can be found at https://mona.fiehnlab.ucdavis.edu/ or https://massbank.us/
 
 ---
 

--- a/backend/app/server/proxy/src/main/mona-web/src/app/components/browser/spectra-browser.component.ts
+++ b/backend/app/server/proxy/src/main/mona-web/src/app/components/browser/spectra-browser.component.ts
@@ -238,6 +238,9 @@ export class SpectraBrowserComponent implements OnInit, AfterViewInit{
     enableTableView() {
       this.pagination.table = true;
       this.suppressNextLoad = true;
+      this.massChartReady = false;
+      setTimeout(() => this.massChartReady = true, 250);
+
       this.setTable();
     }
 

--- a/backend/app/server/proxy/src/main/mona-web/src/app/components/upload/spectra-upload.component.ts
+++ b/backend/app/server/proxy/src/main/mona-web/src/app/components/upload/spectra-upload.component.ts
@@ -291,6 +291,12 @@ export class SpectraUploadComponent implements OnInit, OnDestroy {
       return;
     }
 
+    // Search by library tag instead of file name for libraries
+    if (job.libraryName) {
+      this.router.navigate(['/spectra/browse'], {queryParams: {query: `exists(tags.text:'${job.libraryName}')`}});
+      return;
+    }
+
     const query = job.fileName.split(',')
       .map((name) => name.trim())
       .filter((name) => name.length > 0)

--- a/backend/app/server/proxy/src/main/mona-web/src/app/views/main.html
+++ b/backend/app/server/proxy/src/main/mona-web/src/app/views/main.html
@@ -6,7 +6,7 @@
             <p>
                 MassBank of North America (MoNA) is a metadata-centric, auto-curating repository designed for efficient storage and querying of mass spectral records.
                 It intends to serve as a framework for a centralized, collaborative database of metabolite mass spectra, metadata, and associated compounds.
-                MoNA currently contains {{totalCount | number:'1.0-0'}} mass spectral records from experimental and in-silico libraries, as well as user contributions.
+                MoNA currently contains <strong>{{totalCount | number:'1.0-0'}}</strong> mass spectral records from experimental and in-silico libraries, as well as user contributions.
             </p>
 
             <br />

--- a/backend/app/server/proxy/src/main/mona-web/src/app/views/spectra/dbindex/dbindex.html
+++ b/backend/app/server/proxy/src/main/mona-web/src/app/views/spectra/dbindex/dbindex.html
@@ -64,7 +64,7 @@
                         <p></p>
                     </div>
 
-                    <div style="height: 600px; width: 100%" class="text-center">
+                    <div style="height: 600px; width: 100%" class="d-flex justify-content-center">
                       <nvd3 [options]="metadataChartOptions"
                             [data]="selectedMetadataField.data"></nvd3>
                     </div>
@@ -101,7 +101,7 @@
                   </div>
 
                   <br />
-                    <div class="text-center">
+                    <div class="d-flex justify-content-center">
                       <nvd3 [options]="sunburstOptions"
                             [data]="activeCompoundClassData"
                             class="with-3d-shadow with-transitions"></nvd3>

--- a/backend/app/server/proxy/src/main/mona-web/src/styles/main.scss
+++ b/backend/app/server/proxy/src/main/mona-web/src/styles/main.scss
@@ -32,7 +32,7 @@ i.fa-slack {
 // Space out content a bit
 body {
   padding-top: 20px;
-  padding-bottom: 20px;
+  /* padding-bottom: 20px; */
 }
 
 // Everything but the jumbotron gets side spacing for mobile first views

--- a/backend/core/curation/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/curation/processor/compound/CalculateCompoundProperties.scala
+++ b/backend/core/curation/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/curation/processor/compound/CalculateCompoundProperties.scala
@@ -95,8 +95,10 @@ class CalculateCompoundProperties extends ItemProcessor[Spectrum, Spectrum] with
 
       metaData.append(new MetaData(null, CommonMetaData.TOTAL_EXACT_MASS, compoundConversion.moleculeToTotalExactMass(molecule).toString, false, "computed", true, null))
 
-      // Calculate SMILES
-      metaData.append(new MetaData(null, CommonMetaData.SMILES, compoundConversion.moleculeToSMILES(molecule), false, "computed", true, null))
+      // Calculate SMILES, replacing any previously computed SMILES instead of accumulating duplicates
+      val computedSMILES: String = compoundConversion.moleculeToSMILES(molecule)
+      metaData --= metaData.filter(x => x.getName.toLowerCase == CommonMetaData.SMILES.toLowerCase && x.getComputed)
+      metaData.append(new MetaData(null, CommonMetaData.SMILES, computedSMILES, false, "computed", true, null))
 
 
       // Calculate InChI and InChIKey and only add them to the record if they differ from provided values

--- a/backend/core/curation/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/curation/processor/compound/CompoundProcessor.scala
+++ b/backend/core/curation/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/curation/processor/compound/CompoundProcessor.scala
@@ -41,7 +41,8 @@ class CompoundProcessor extends LazyLogging {
           (null, null)
       }
 
-    def isValid(result: (String, IAtomContainer)): Boolean = result != null && result._1 != null && result._2 != null
+    def isValid(result: (String, IAtomContainer)): Boolean =
+      result != null && result._1 != null && result._2 != null && result._2.getAtomCount > 0
 
     // Try each structure source in priority order, stopping at the first that yields a molecule.
     // The InChIKey lookup is an external call, so it only runs as a last resort when no structure
@@ -107,9 +108,9 @@ class CompoundInChIProcessor extends AbstractCompoundProcessor {
     val inchiMetaData: Option[MetaData] = compound.getMetaData.asScala.find(_.getName.toLowerCase == CommonMetaData.INCHI_CODE.toLowerCase)
 
     val inchi: String =
-      if (compound.getInchi != null && !compound.getInchi.isEmpty)
+      if (compound.getInchi != null && compound.getInchi.startsWith("InChI="))
         compound.getInchi
-      else if (inchiMetaData.isDefined && inchiMetaData.get.getValue.toString != "")
+      else if (inchiMetaData.isDefined && inchiMetaData.get.getValue.toString.startsWith("InChI="))
         inchiMetaData.get.getValue.toString
       else
         null

--- a/backend/core/curation/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/curation/processor/compound/CompoundProcessor.scala
+++ b/backend/core/curation/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/curation/processor/compound/CompoundProcessor.scala
@@ -144,7 +144,9 @@ class CompoundInChIProcessor extends AbstractCompoundProcessor {
 class CompoundSMILESProcessor extends AbstractCompoundProcessor with LazyLogging {
 
   def process(compound: Compound, id: String, impacts: ArrayBuffer[Impacts]): (String, IAtomContainer) = {
-    val smiles: Option[MetaData] = compound.getMetaData.asScala.find(_.getName.toLowerCase == CommonMetaData.SMILES.toLowerCase)
+    val smiles: Option[MetaData] = compound.getMetaData.asScala
+      .filter(_.getName.toLowerCase == CommonMetaData.SMILES.toLowerCase)
+      .find(m => m.getValue != null && m.getValue.toString.nonEmpty)
 
     // Parse SMILES
     if (smiles.isDefined && !smiles.get.getValue.toString.isEmpty) {

--- a/backend/core/domain/src/main/java/edu/ucdavis/fiehnlab/mona/backend/core/domain/Compound.java
+++ b/backend/core/domain/src/main/java/edu/ucdavis/fiehnlab/mona/backend/core/domain/Compound.java
@@ -174,11 +174,11 @@ public class Compound implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Compound that = (Compound) o;
-        return Objects.equals(id, that.id) && Objects.equals(spectrum, that.spectrum) && Objects.equals(kind, that.kind) && Objects.equals(tags, that.tags) && Objects.equals(inchi, that.inchi) && Objects.equals(names, that.names) && Objects.equals(molFile, that.molFile) && Objects.equals(computed, that.computed) && Objects.equals(inchiKey, that.inchiKey) && Objects.equals(metaData, that.metaData) && Objects.equals(classification, that.classification);
+        return Objects.equals(id, that.id) && Objects.equals(kind, that.kind) && Objects.equals(tags, that.tags) && Objects.equals(inchi, that.inchi) && Objects.equals(names, that.names) && Objects.equals(molFile, that.molFile) && Objects.equals(computed, that.computed) && Objects.equals(inchiKey, that.inchiKey) && Objects.equals(metaData, that.metaData) && Objects.equals(classification, that.classification);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, spectrum, kind, tags, inchi, names, molFile, computed, inchiKey, metaData, classification);
+        return Objects.hash(id, kind, tags, inchi, names, molFile, computed, inchiKey, metaData, classification);
     }
 }

--- a/backend/core/domain/src/main/java/edu/ucdavis/fiehnlab/mona/backend/core/domain/Library.java
+++ b/backend/core/domain/src/main/java/edu/ucdavis/fiehnlab/mona/backend/core/domain/Library.java
@@ -84,11 +84,11 @@ public class Library implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Library library1 = (Library) o;
-        return Objects.equals(id, library1.id) && Objects.equals(spectrum, library1.spectrum) && Objects.equals(description, library1.description) && Objects.equals(link, library1.link) && Objects.equals(library, library1.library);
+        return Objects.equals(id, library1.id) && Objects.equals(description, library1.description) && Objects.equals(link, library1.link) && Objects.equals(library, library1.library);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, spectrum, description, link, library);
+        return Objects.hash(id, description, link, library);
     }
 }

--- a/backend/core/domain/src/main/java/edu/ucdavis/fiehnlab/mona/backend/core/domain/MetaData.java
+++ b/backend/core/domain/src/main/java/edu/ucdavis/fiehnlab/mona/backend/core/domain/MetaData.java
@@ -203,11 +203,11 @@ public class MetaData implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         MetaData metaData = (MetaData) o;
-        return Objects.equals(id, metaData.id) && Objects.equals(spectrumMetadata, metaData.spectrumMetadata) && Objects.equals(spectrumAnnotation, metaData.spectrumAnnotation) && Objects.equals(compoundMetadata, metaData.compoundMetadata) && Objects.equals(compoundClassification, metaData.compoundClassification) && Objects.equals(url, metaData.url) && Objects.equals(name, metaData.name) && Objects.equals(value, metaData.value) && Objects.equals(hidden, metaData.hidden) && Objects.equals(category, metaData.category) && Objects.equals(computed, metaData.computed) && Objects.equals(unit, metaData.unit);
+        return Objects.equals(id, metaData.id) && Objects.equals(url, metaData.url) && Objects.equals(name, metaData.name) && Objects.equals(value, metaData.value) && Objects.equals(hidden, metaData.hidden) && Objects.equals(category, metaData.category) && Objects.equals(computed, metaData.computed) && Objects.equals(unit, metaData.unit);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, spectrumMetadata, spectrumAnnotation, compoundMetadata, compoundClassification, url, name, value, hidden, category, computed, unit);
+        return Objects.hash(id, url, name, value, hidden, category, computed, unit);
     }
 }

--- a/backend/core/domain/src/main/java/edu/ucdavis/fiehnlab/mona/backend/core/domain/Score.java
+++ b/backend/core/domain/src/main/java/edu/ucdavis/fiehnlab/mona/backend/core/domain/Score.java
@@ -88,11 +88,11 @@ public class Score implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Score score1 = (Score) o;
-        return Objects.equals(id, score1.id) && Objects.equals(spectrum, score1.spectrum) && Objects.equals(impacts, score1.impacts) && Objects.equals(score, score1.score) && Objects.equals(relativeScore, score1.relativeScore) && Objects.equals(scaledScore, score1.scaledScore);
+        return Objects.equals(id, score1.id) && Objects.equals(impacts, score1.impacts) && Objects.equals(score, score1.score) && Objects.equals(relativeScore, score1.relativeScore) && Objects.equals(scaledScore, score1.scaledScore);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, spectrum, impacts, score, relativeScore, scaledScore);
+        return Objects.hash(id, impacts, score, relativeScore, scaledScore);
     }
 }

--- a/backend/core/domain/src/main/java/edu/ucdavis/fiehnlab/mona/backend/core/domain/SpectrumSubmitter.java
+++ b/backend/core/domain/src/main/java/edu/ucdavis/fiehnlab/mona/backend/core/domain/SpectrumSubmitter.java
@@ -94,12 +94,12 @@ public class SpectrumSubmitter {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SpectrumSubmitter that = (SpectrumSubmitter) o;
-        return Objects.equals(id, that.id) && Objects.equals(spectrum, that.spectrum) && Objects.equals(emailAddress, that.emailAddress) && Objects.equals(firstName, that.firstName) && Objects.equals(lastName, that.lastName) && Objects.equals(institution, that.institution);
+        return Objects.equals(id, that.id) && Objects.equals(emailAddress, that.emailAddress) && Objects.equals(firstName, that.firstName) && Objects.equals(lastName, that.lastName) && Objects.equals(institution, that.institution);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, spectrum, emailAddress, firstName, lastName, institution);
+        return Objects.hash(id, emailAddress, firstName, lastName, institution);
     }
 
     @Override

--- a/backend/core/domain/src/main/java/edu/ucdavis/fiehnlab/mona/backend/core/domain/Splash.java
+++ b/backend/core/domain/src/main/java/edu/ucdavis/fiehnlab/mona/backend/core/domain/Splash.java
@@ -102,11 +102,11 @@ public class Splash implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Splash splash1 = (Splash) o;
-        return id.equals(splash1.id) && spectrum.equals(splash1.spectrum) && Objects.equals(block1, splash1.block1) && Objects.equals(block2, splash1.block2) && Objects.equals(block3, splash1.block3) && Objects.equals(block4, splash1.block4) && Objects.equals(splash, splash1.splash);
+        return Objects.equals(id, splash1.id) && Objects.equals(block1, splash1.block1) && Objects.equals(block2, splash1.block2) && Objects.equals(block3, splash1.block3) && Objects.equals(block4, splash1.block4) && Objects.equals(splash, splash1.splash);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, spectrum, block1, block2, block3, block4, splash);
+        return Objects.hash(id, block1, block2, block3, block4, splash);
     }
 }

--- a/backend/core/domain/src/main/java/edu/ucdavis/fiehnlab/mona/backend/core/domain/Tag.java
+++ b/backend/core/domain/src/main/java/edu/ucdavis/fiehnlab/mona/backend/core/domain/Tag.java
@@ -67,11 +67,11 @@ public class Tag implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Tag tag = (Tag) o;
-        return Objects.equals(id, tag.id) && Objects.equals(spectrum, tag.spectrum) && Objects.equals(compound, tag.compound) && Objects.equals(text, tag.text) && Objects.equals(ruleBased, tag.ruleBased);
+        return Objects.equals(id, tag.id) && Objects.equals(text, tag.text) && Objects.equals(ruleBased, tag.ruleBased);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, spectrum, compound, text, ruleBased);
+        return Objects.hash(id, text, ruleBased);
     }
 }

--- a/backend/services/curation-scheduler/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/core/curation/controller/CurationController.scala
+++ b/backend/services/curation-scheduler/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/core/curation/controller/CurationController.scala
@@ -5,7 +5,6 @@ import javax.servlet.http.HttpServletRequest
 import com.typesafe.scalalogging.LazyLogging
 import edu.ucdavis.fiehnlab.mona.backend.core.curation.service.{CurationRunner, CurationService}
 import edu.ucdavis.fiehnlab.mona.backend.core.domain.Spectrum
-import edu.ucdavis.fiehnlab.mona.backend.core.persistence.postgresql.service.SpectrumPersistenceService
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.amqp.rabbit.core.RabbitAdmin
 import org.springframework.beans.factory.annotation.{Autowired, Qualifier, Value}
@@ -21,9 +20,6 @@ import org.springframework.web.bind.annotation._
 @RestController
 @RequestMapping(value = Array("/rest/curation"))
 class CurationController extends LazyLogging {
-  @Autowired
-  val spectrumPersistenceService: SpectrumPersistenceService = null
-
   @Autowired
   val curationService: CurationService = null
 
@@ -52,12 +48,11 @@ class CurationController extends LazyLogging {
     */
   @RequestMapping(path = Array("/{id}"))
   def curateById(@PathVariable("id") id: String, request: HttpServletRequest): ResponseEntity[CurationJobScheduled] = {
-    val spectrum = spectrumPersistenceService.findByMonaId(id)
+    val spectrum = curationService.curateById(id)
 
     if (spectrum == null) {
       new ResponseEntity(HttpStatus.NOT_FOUND)
     } else {
-      curationService.scheduleSpectrum(spectrum)
       new ResponseEntity[CurationJobScheduled](CurationJobScheduled(1), HttpStatus.OK)
     }
   }

--- a/backend/services/curation-scheduler/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/core/curation/service/CurationService.scala
+++ b/backend/services/curation-scheduler/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/core/curation/service/CurationService.scala
@@ -2,11 +2,14 @@ package edu.ucdavis.fiehnlab.mona.backend.core.curation.service
 
 import edu.ucdavis.fiehnlab.mona.backend.core.domain.Spectrum
 import edu.ucdavis.fiehnlab.mona.backend.core.persistence.postgresql.service.SpectrumPersistenceService
+import org.hibernate.Hibernate
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.batch.item.ItemProcessor
 import org.springframework.beans.factory.annotation.{Autowired, Qualifier}
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+
+import scala.jdk.CollectionConverters._
 
 /**
   * Created by wohlg on 4/12/2016.
@@ -41,8 +44,10 @@ class CurationService {
     * Loads a single keyset (cursor) page of spectra and schedules each one for curation
     * Walks the id ordering with a cursor (id < lastId) instead of offset paging, so there is no
     * per-page count query and no growing offset on large runs. Runs in a read-only transaction so
-    * a Hibernate session stays open while each spectrum is serialized to the queue, letting lazy
-    * associations (e.g. compound) initialize
+    * a Hibernate session stays open while each spectrum's lazy associations are force-initialized
+    * before being handed to the AMQP converter. MonaMessageConverter's Hibernate5Module serializes
+    * an association Jackson finds still uninitialized as null/empty instead of loading it, so the
+    * load has to happen explicitly here rather than relying on serialization to trigger it
     *
     * @param query  optional query, or null/empty for all spectra
     * @param lastId id of the last spectrum scheduled on the previous page, or null for the first page
@@ -52,8 +57,51 @@ class CurationService {
   @Transactional(readOnly = true)
   def scheduleSpectraKeysetPage(query: String, lastId: String, limit: Int): java.util.List[Spectrum] = {
     val page: java.util.List[Spectrum] = spectrumPersistenceService.findAllForExport(query, lastId, limit)
-    page.forEach(spectrum => scheduleSpectrum(spectrum))
+    page.forEach(spectrum => {
+      initializeLazyAssociations(spectrum)
+      scheduleSpectrum(spectrum)
+    })
     page
+  }
+
+  /**
+    * Loads a single spectrum by id and schedules it for curation. Fetch, lazy-association
+    * initialization, and enqueue all happen inside one transaction here rather than relying on
+    * open-session-in-view to keep the session alive between spectrumPersistenceService.findByMonaId
+    * returning and scheduleSpectrum serializing the result
+    *
+    * @param id
+    * @return the loaded spectrum, or null if no spectrum exists with that id
+    */
+  @Transactional(readOnly = true)
+  def curateById(id: String): Spectrum = {
+    val spectrum: Spectrum = spectrumPersistenceService.findByMonaId(id)
+    if (spectrum != null) {
+      initializeLazyAssociations(spectrum)
+      scheduleSpectrum(spectrum)
+    }
+    spectrum
+  }
+
+  /**
+    * Forces the compound/metaData/tags collections, and each compound's own nested
+    * tags/names/metaData/classification, to load while the caller's session is still open
+    *
+    * @param spectrum
+    */
+  private def initializeLazyAssociations(spectrum: Spectrum): Unit = {
+    Hibernate.initialize(spectrum.getCompound)
+    Hibernate.initialize(spectrum.getMetaData)
+    Hibernate.initialize(spectrum.getTags)
+
+    if (spectrum.getCompound != null) {
+      spectrum.getCompound.asScala.foreach { compound =>
+        Hibernate.initialize(compound.getMetaData)
+        Hibernate.initialize(compound.getNames)
+        Hibernate.initialize(compound.getTags)
+        Hibernate.initialize(compound.getClassification)
+      }
+    }
   }
 
   /**

--- a/backend/services/similarity/src/main/scala/edu/ucdavis/fiehnlab/mona/core/similarity/service/SimilarityPopulationService.scala
+++ b/backend/services/similarity/src/main/scala/edu/ucdavis/fiehnlab/mona/core/similarity/service/SimilarityPopulationService.scala
@@ -39,7 +39,10 @@ class SimilarityPopulationService extends LazyLogging {
       } else {
         null
       }
-    val theoreticalAdducts: mutable.Buffer[Double] = biologicalCompound.getMetaData.asScala.filter(x => x.getCategory == "theoretical adduct").map(_.getValue.toDouble)
+    val theoreticalAdducts: mutable.Buffer[Double] = Option(biologicalCompound) match {
+      case Some(compound) => compound.getMetaData.asScala.filter(x => x.getCategory == "theoretical adduct").map(_.getValue.toDouble)
+      case None => mutable.Buffer.empty
+    }
 
     if (precursorMZ.isDefined) {
       try {
@@ -74,7 +77,7 @@ class SimilarityPopulationService extends LazyLogging {
           logger.debug(s"\tIndexed spectrum #$counter with id ${spectrum.getId}, main index size = $mainIndexSize, peak index size = $peakIndexSize")
         }
       } catch {
-        case nfe: NumberFormatException => logger.error(s"Invalid spectrum: ${spectrum}")
+        case t: Throwable => logger.error(s"Invalid spectrum: ${spectrum}", t)
       }
 
       if (counter % sessionClearInterval == 0) {


### PR DESCRIPTION
- Use tags instead of origin name for library upload searches
- Fixed a curation bug causing 400s due to lazy loading
- Fixed sunburst chart and pie chart being off centered in statistics page
- Fixed a bug in the similarity service where a compound with biologicalCompound as NULL would cause NPE and crash the service
- Bold the spectra total count on home page
- Fixed spectrum charts not loading after switching to compact view in spectra browser