### PR TITLE
Curation Queue Recovery Fix

### DIFF
--- a/backend/app/server/proxy/src/main/mona-web/src/app/views/navbar/searchBox.html
+++ b/backend/app/server/proxy/src/main/mona-web/src/app/views/navbar/searchBox.html
@@ -7,7 +7,7 @@
                placement="bottom" name="search-box"/>
 
         <span class="input-group-btn">
-            <button data-toggle="collapse" data-target=".navbar-collapse.show" class="btn btn-repeat btn-search" type="submit" (click)="performSimpleQuery(searchBoxQuery)">
+            <button data-toggle="collapse" data-target=".navbar-collapse.show" class="btn btn-repeat btn-search" type="submit" (click)="performSimpleQuery(searchBoxQuery)" aria-label="Search">
               <fa-icon [icon]="faSearch"></fa-icon>
             </button>
         </span>

--- a/backend/app/server/proxy/src/main/mona-web/src/app/views/spectra/upload/uploadStatus.html
+++ b/backend/app/server/proxy/src/main/mona-web/src/app/views/spectra/upload/uploadStatus.html
@@ -87,7 +87,8 @@
                                     Upload cancelled before completion
                                 </div>
                                 <div *ngIf="job.status === 'DELETED' && job.deletedDate" class="small text-muted">
-                                    <fa-icon [icon]="faTrash" size="xs"></fa-icon> {{job.deletedDate | date:'shortDate'}} {{job.deletedDate | date:'shortTime'}}
+                                    <fa-icon [icon]="faTrash" size="xs"></fa-icon> {{job.deletedDate | date:'shortDate'}}<br/>
+                                    {{job.deletedDate | date:'shortTime'}}
                                 </div>
                             </td>
                             <td class="align-middle">

--- a/backend/core/amqp/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/core/amqp/event/bus/EventBus.scala
+++ b/backend/core/amqp/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/core/amqp/event/bus/EventBus.scala
@@ -7,9 +7,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.typesafe.scalalogging.LazyLogging
 import edu.ucdavis.fiehnlab.mona.backend.core.domain.event.Event
 import edu.ucdavis.fiehnlab.mona.backend.core.domain.io.json.MonaMapper
-import org.springframework.amqp.core.FanoutExchange
+import org.springframework.amqp.core.{Declarable, FanoutExchange}
 import org.springframework.amqp.rabbit.core.{RabbitAdmin, RabbitTemplate}
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 
 import scala.reflect.ClassTag
 
@@ -46,14 +47,22 @@ class EventBus[T: ClassTag](val busName: String = "mona-event-bus") extends Lazy
   @Autowired
   private val rabbitAdmin: RabbitAdmin = null
 
+  @Autowired
+  private val beanFactory: ConfigurableListableBeanFactory = null
+
   val objectMapper: ObjectMapper = MonaMapper.create
 
-  val exchange = new FanoutExchange(busName, false, true)
+  /**
+    * Durable so a broker restart cannot drop the exchange, and not auto-delete so it also survives its last
+    * binding going away when every listener disconnects.
+    */
+  val exchange = new FanoutExchange(busName, true, false)
 
 
   @PostConstruct
   def init(): Unit = {
     rabbitAdmin.declareExchange(exchange)
+    BusDeclarations.register(beanFactory, s"$busName-exchange", exchange)
     rabbitAdmin.afterPropertiesSet()
   }
 
@@ -66,6 +75,30 @@ class EventBus[T: ClassTag](val busName: String = "mona-event-bus") extends Lazy
     logger.debug(s"sending event to bus: ${event.content.getClass.getSimpleName}")
     rabbitTemplate.convertAndSend(busName, "", event)
     logger.debug("event sent!")
+  }
+}
+
+/**
+  * The bus builds its exchange, queues and bindings at runtime rather than as configuration beans, since a
+  * listener only knows its queue name once the application name has been resolved. 
+  *
+  * Registering each declaration as a singleton bean puts it in the set RabbitAdmin walks in initialize(),
+  * which its own ConnectionListener runs on every connection creation. 
+  */
+object BusDeclarations {
+
+  /**
+    * Register a declaration under the given bean name, ignoring a name that is already taken so a second
+    * bus or listener sharing a name cannot fail the context
+    *
+    * @param beanFactory
+    * @param name
+    * @param declarable
+    */
+  def register(beanFactory: ConfigurableListableBeanFactory, name: String, declarable: Declarable): Unit = {
+    if (!beanFactory.containsSingleton(name)) {
+      beanFactory.registerSingleton(name, declarable)
+    }
   }
 }
 

--- a/backend/core/amqp/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/core/amqp/event/bus/EventBusListener.scala
+++ b/backend/core/amqp/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/core/amqp/event/bus/EventBusListener.scala
@@ -13,6 +13,7 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory
 import org.springframework.amqp.rabbit.core.RabbitAdmin
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer
 import org.springframework.beans.factory.annotation.{Autowired, Value}
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 
 import scala.reflect._
 
@@ -30,6 +31,9 @@ abstract class EventBusListener[T: ClassTag](val eventBus: EventBus[T]) extends 
 
   @Autowired
   private val rabbitAdmin: RabbitAdmin = null
+
+  @Autowired
+  private val beanFactory: ConfigurableListableBeanFactory = null
 
   @Value("${spring.application.name:unknown}")
   private var queueName = "unknown"
@@ -52,9 +56,18 @@ abstract class EventBusListener[T: ClassTag](val eventBus: EventBus[T]) extends 
     }
 
     val queue = new Queue(queueName, false, false, true)
+    val binding = BindingBuilder.bind(queue).to(eventBus.exchange)
 
     rabbitAdmin.declareQueue(queue)
-    rabbitAdmin.declareBinding(BindingBuilder.bind(queue).to(eventBus.exchange))
+    rabbitAdmin.declareBinding(binding)
+
+    // The declarations above only cover this startup. Registering them as beans as well puts them in the
+    // set RabbitAdmin rebuilds on every connection, so a broker restart no longer leaves this listener
+    // with no queue to consume from. The names are derived from the queue, which is unique per listener,
+    // so several listeners in one context keep their own queue and each still receive every event
+    BusDeclarations.register(beanFactory, s"$queueName-queue", queue)
+    BusDeclarations.register(beanFactory, s"$queueName-binding", binding)
+
     rabbitAdmin.afterPropertiesSet()
 
     logger.info(s"connecting to queue: ${queue.getName}")
@@ -63,6 +76,10 @@ abstract class EventBusListener[T: ClassTag](val eventBus: EventBus[T]) extends 
     container.setMessageListener(this)
     container.setAmqpAdmin(rabbitAdmin)
     container.setExclusive(exclusive)
+
+    // A queue that disappeared with the broker must not stop this consumer for good, it keeps retrying
+    // until RabbitAdmin has re-declared the queue on reconnect
+    container.setMissingQueuesFatal(false)
 
     logger.info("starting container")
     container.start()

--- a/backend/core/amqp/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/core/amqp/event/config/BusConfig.scala
+++ b/backend/core/amqp/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/core/amqp/event/config/BusConfig.scala
@@ -6,7 +6,8 @@ import edu.ucdavis.fiehnlab.mona.backend.core.amqp.event.bus.{EventBus, Received
 import edu.ucdavis.fiehnlab.mona.backend.core.amqp.event.converter.MonaMessageConverter
 import edu.ucdavis.fiehnlab.mona.backend.core.domain.Spectrum
 import edu.ucdavis.fiehnlab.mona.backend.core.domain.config.DomainConfig
-import org.springframework.amqp.rabbit.connection.ConnectionFactory
+import org.springframework.amqp.core.ReturnedMessage
+import org.springframework.amqp.rabbit.connection.{CachingConnectionFactory, ConnectionFactory}
 import org.springframework.amqp.rabbit.core.{RabbitAdmin, RabbitTemplate}
 import org.springframework.amqp.support.converter._
 import org.springframework.context.annotation.{Bean, Configuration, Import, Primary}
@@ -36,10 +37,38 @@ class BusConfig extends LazyLogging {
   @Bean
   def rabbitTemplate(jsonConverter: MessageConverter, connectionFactory: ConnectionFactory): RabbitTemplate = {
     logger.info("creating custom rabbit template")
+
+    connectionFactory match {
+      case caching: CachingConnectionFactory => caching.setPublisherReturns(true)
+      case _ => logger.warn("connection factory does not support publisher returns, undeliverable messages will not be reported")
+    }
+
     val template = new RabbitTemplate(connectionFactory)
     template.setMessageConverter(jsonConverter)
+
+    template.setMandatory(true)
+    template.setReturnsCallback(new RabbitTemplate.ReturnsCallback {
+      override def returnedMessage(returned: ReturnedMessage): Unit = {
+        // The notification bus has no subscriber outside tests, so nothing routing off it is expected
+        // rather than a lost event, and reporting it would bury the cases that matter
+        if (returned.getExchange != BusConfig.NotificationBusName) {
+          logger.error(s"message reached no queue, exchange '${returned.getExchange}' " +
+            s"routing key '${returned.getRoutingKey}': ${returned.getReplyText}")
+        }
+      }
+    })
+
     template
   }
+}
+
+object BusConfig {
+
+  /**
+    * Named here rather than inline so the notification bus and the returns callback that has to recognise it
+    * cannot drift apart
+    */
+  val NotificationBusName: String = "mona-notification-bus"
 }
 
 /**
@@ -83,7 +112,7 @@ class MonaEventBusCounterConfiguration {
 class MonaNotificationBusConfiguration {
 
   @Bean
-  def notificationsBus: EventBus[Notification] = new EventBus[Notification]("mona-notification-bus")
+  def notificationsBus: EventBus[Notification] = new EventBus[Notification](BusConfig.NotificationBusName)
 }
 
 @Import(Array(classOf[BusConfig], classOf[MonaNotificationBusConfiguration]))

--- a/backend/core/amqp/src/test/scala/edu/ucdavis/fiehnlab/mona/backend/core/amqp/event/bus/EventBusRecoveryTest.scala
+++ b/backend/core/amqp/src/test/scala/edu/ucdavis/fiehnlab/mona/backend/core/amqp/event/bus/EventBusRecoveryTest.scala
@@ -1,0 +1,87 @@
+package edu.ucdavis.fiehnlab.mona.backend.core.amqp.event.bus
+
+import java.io.InputStreamReader
+import java.util.Date
+import java.util.concurrent.CountDownLatch
+import edu.ucdavis.fiehnlab.mona.backend.core.domain.Spectrum
+import edu.ucdavis.fiehnlab.mona.backend.core.domain.event.Event
+import edu.ucdavis.fiehnlab.mona.backend.core.domain.io.json.JSONDomainReader
+import org.scalatest.concurrent.Eventually
+import org.scalatest.wordspec.AnyWordSpec
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory
+import org.springframework.amqp.rabbit.core.RabbitAdmin
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.{Bean, Configuration, Import}
+import edu.ucdavis.fiehnlab.mona.backend.core.amqp.event.config.BusConfig
+import org.springframework.test.context.{ActiveProfiles, TestContextManager}
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+/**
+  * Pins the behaviour the bus declarations exist for. A broker restart deletes the exchange and, once the
+  * consumer drops with it, the auto-delete listener queue as well, while the application itself keeps
+  * running and so never re-runs the @PostConstruct that originally declared them. Nothing then rebuilt the
+  * topology and every published event was silently dropped until the services were restarted by hand
+  */
+@SpringBootTest(classes = Array(classOf[RecoveryTestConfig]))
+@ActiveProfiles(Array("test"))
+class EventBusRecoveryTest extends AnyWordSpec with Eventually {
+
+  @Autowired
+  val eventBus: EventBus[Spectrum] = null
+
+  @Autowired
+  val listener: RecoveryTestListener = null
+
+  @Autowired
+  val rabbitAdmin: RabbitAdmin = null
+
+  @Autowired
+  val connectionFactory: CachingConnectionFactory = null
+
+  new TestContextManager(this.getClass).prepareTestInstance(this)
+
+  "an event bus whose topology was destroyed underneath a running application" should {
+
+    "rebuild it on the next connection and keep delivering events" in {
+      val reader: JSONDomainReader[Spectrum] = JSONDomainReader.create[Spectrum]
+      val spectrum: Spectrum = reader.read(new InputStreamReader(getClass.getResourceAsStream("/monaRecord.json")))
+
+      assert(listener.events.getCount == 1)
+
+      // What a broker restart does to the bus, without restarting the broker. Dropping the connection also
+      // takes the auto-delete queue with it, since its only consumer goes away
+      rabbitAdmin.deleteExchange(eventBus.busName)
+      connectionFactory.resetConnection()
+
+      // Events published before the container has reconnected are genuinely lost, so keep publishing until
+      // one lands. Without the declarations being re-registered no event ever arrives
+      eventually(timeout(30 seconds), interval(1 second)) {
+        eventBus.sendEvent(Event[Spectrum](spectrum, new Date, "custom"))
+        assert(listener.events.getCount == 0)
+      }
+    }
+  }
+}
+
+@Configuration
+@EnableAutoConfiguration
+@Import(Array(classOf[BusConfig]))
+class RecoveryTestConfig {
+
+  @Bean
+  def eventBus: EventBus[Spectrum] = new EventBus[Spectrum]("mona-recovery-test-bus")
+
+  @Bean
+  def recoveryListener(eventBus: EventBus[Spectrum]): RecoveryTestListener = new RecoveryTestListener(eventBus)
+}
+
+class RecoveryTestListener(override val eventBus: EventBus[Spectrum]) extends EventBusListener[Spectrum](eventBus) {
+
+  val events = new CountDownLatch(1)
+
+  override def received(event: Event[Spectrum]): Unit = events.countDown()
+}

--- a/backend/core/rest/persistence-server/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/core/persistence/rest/server/config/RestServerConfig.scala
+++ b/backend/core/rest/persistence-server/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/core/persistence/rest/server/config/RestServerConfig.scala
@@ -87,6 +87,9 @@ class RestServerConfig extends WebSecurityConfigurerAdapter {
 
       .antMatchers(HttpMethod.POST, "/rest/feedback")
       .antMatchers(HttpMethod.POST, "/rest/spectra/count")
+
+      // errors are re-dispatched to /error and report a wrong 401 error message without this
+      .antMatchers("/error")
   }
 }
 

--- a/backend/core/rest/persistence-server/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/core/persistence/rest/server/controller/advice/FilterExceptionHandler.scala
+++ b/backend/core/rest/persistence-server/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/core/persistence/rest/server/controller/advice/FilterExceptionHandler.scala
@@ -1,0 +1,65 @@
+package edu.ucdavis.fiehnlab.mona.backend.core.persistence.rest.server.controller.advice
+
+import com.turkraft.springfilter.exception.{InternalFilterException, SpringFilterException}
+import com.typesafe.scalalogging.LazyLogging
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.{HttpStatus, ResponseEntity}
+import org.springframework.web.bind.annotation.{ExceptionHandler, RestControllerAdvice}
+
+import javax.servlet.http.HttpServletRequest
+
+/**
+  * Turns spring-filter failures into proper status codes instead of letting them escape the
+  * controllers
+  */
+@RestControllerAdvice
+class FilterExceptionHandler extends LazyLogging {
+
+  @Autowired
+  val httpServletRequest: HttpServletRequest = null
+
+  /**
+    * the offending url is the useful part of the log line, since it identifies the client or the
+    * stale link that still sends the old syntax
+    */
+  private def describeRequest: String = {
+    if (httpServletRequest == null) {
+      "unknown request"
+    } else if (httpServletRequest.getQueryString == null) {
+      httpServletRequest.getRequestURI
+    } else {
+      s"${httpServletRequest.getRequestURI}?${httpServletRequest.getQueryString}"
+    }
+  }
+
+  /**
+    * bad syntax, unknown functions and unauthorized paths all originate in the submitted query, so
+    * they are client errors. The stack trace adds nothing over the message, so only the request and
+    * the reason are logged
+    */
+  @ExceptionHandler(Array(classOf[SpringFilterException]))
+  def handleBadFilter(e: SpringFilterException): ResponseEntity[java.util.Map[String, String]] = {
+    logger.warn(s"rejecting malformed filter query on $describeRequest: ${e.getMessage}")
+
+    val body: java.util.Map[String, String] = java.util.Map.of(
+      "error", s"invalid query syntax: ${e.getMessage}",
+      "hint", "queries use spring-filter syntax, for example exists(metaData.name:'ionization mode' and metaData.value:'positive'). The older RSQL form using == and =q= is no longer supported"
+    )
+
+    new ResponseEntity(body, HttpStatus.BAD_REQUEST)
+  }
+
+  /**
+    * an internal filter failure is a fault on our side rather than a bad query, so it keeps its 500
+    * and its stack trace. Handling it still beats letting it escape, since the escaped version
+    * reaches the caller as an empty 401
+    */
+  @ExceptionHandler(Array(classOf[InternalFilterException]))
+  def handleInternalFilterFailure(e: InternalFilterException): ResponseEntity[java.util.Map[String, String]] = {
+    logger.error(s"filter evaluation failed internally on $describeRequest: ${e.getMessage}", e)
+
+    val body: java.util.Map[String, String] = java.util.Map.of("error", "the query could not be evaluated")
+
+    new ResponseEntity(body, HttpStatus.INTERNAL_SERVER_ERROR)
+  }
+}

--- a/backend/core/rest/persistence-server/src/test/scala/edu/ucdavis/fiehnlab/mona/backend/core/persistence/rest/server/controller/advice/FilterExceptionHandlerSpec.scala
+++ b/backend/core/rest/persistence-server/src/test/scala/edu/ucdavis/fiehnlab/mona/backend/core/persistence/rest/server/controller/advice/FilterExceptionHandlerSpec.scala
@@ -1,0 +1,90 @@
+package edu.ucdavis.fiehnlab.mona.backend.core.persistence.rest.server.controller.advice
+
+import com.turkraft.springfilter.exception.{BadFilterSyntaxException, InternalFilterException}
+import com.turkraft.springfilter.parser.Filter
+import org.scalatest.flatspec.AnyFlatSpec
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.bind.annotation.{GetMapping, RequestMapping, RestController}
+
+/**
+  * Unit tests for the filter exception advice. Driven through a standalone MockMvc setup with a
+  * stub controller, so no Spring context, security chain or database is involved
+  */
+class FilterExceptionHandlerSpec extends AnyFlatSpec {
+
+  /**
+    * Stub endpoints raising the exceptions the advice is expected to translate
+    *
+    * Nested inside the spec on purpose. This package sits under the component scan RestServerConfig
+    * declares, and scanning does not separate test classes from main ones, so a top level controller
+    * here would be registered as a bean and mount /rest/stub in every integration test context. An
+    * inner class is not an independent candidate, so the scanner skips it while MockMvc still takes it
+    */
+  @RestController
+  @RequestMapping(Array("/rest/stub"))
+  class FilterThrowingController {
+
+    @GetMapping(path = Array("/bad"))
+    def bad(): String = throw new BadFilterSyntaxException("token recognition error at: '='", null)
+
+    @GetMapping(path = Array("/internal"))
+    def internal(): String = throw new InternalFilterException("no such path in the entity graph", null)
+
+    @GetMapping(path = Array("/ok"))
+    def ok(): String = "fine"
+  }
+
+  private val mockMvc: MockMvc = MockMvcBuilders
+    .standaloneSetup(new FilterThrowingController)
+    .setControllerAdvice(new FilterExceptionHandler)
+    .build()
+
+  "FilterExceptionHandler" should "answer 400 for a query the filter parser cannot read" in {
+    val response = mockMvc.perform(get("/rest/stub/bad")).andReturn().getResponse
+
+    assert(response.getStatus == 400)
+    assert(response.getContentAsString.contains("invalid query syntax"))
+    assert(response.getContentAsString.contains("token recognition error"))
+  }
+
+  it should "point a rejected query at the supported syntax" in {
+    val response = mockMvc.perform(get("/rest/stub/bad")).andReturn().getResponse
+
+    assert(response.getContentAsString.contains("spring-filter syntax"))
+  }
+
+  it should "keep an internal filter failure a server error" in {
+    val response = mockMvc.perform(get("/rest/stub/internal")).andReturn().getResponse
+
+    assert(response.getStatus == 500)
+    assert(response.getContentAsString.contains("could not be evaluated"))
+  }
+
+  it should "leave a successful request alone" in {
+    val response = mockMvc.perform(get("/rest/stub/ok")).andReturn().getResponse
+
+    assert(response.getStatus == 200)
+  }
+
+  /**
+    * Guards the assumption the advice is built on. The legacy RSQL syntax MoNA served before the
+    * move to spring-filter has no '=' token in the current grammar, which is what produces the
+    * rejections this advice reports. Should an upgrade start accepting it, the hint in the response
+    * would be wrong and this fails first
+    */
+  "the filter parser" should "reject the legacy RSQL syntax" in {
+    assertThrows[BadFilterSyntaxException] {
+      Filter.from("metaData=q='name==\"ionization mode\" and value==\"positive\"'")
+    }
+
+    assertThrows[BadFilterSyntaxException] {
+      Filter.from("compound.inchiKey==\"KWILGNNWGSNMPA-UHFFFAOYSA-N\"")
+    }
+  }
+
+  it should "accept the syntax the response hint recommends" in {
+    Filter.from("exists(metaData.name:'ionization mode' and metaData.value:'positive')")
+  }
+}

--- a/backend/core/rest/persistence-server/src/test/scala/edu/ucdavis/fiehnlab/mona/backend/core/persistence/rest/server/controller/spectrum/SpectrumRestControllerSecurityTest.scala
+++ b/backend/core/rest/persistence-server/src/test/scala/edu/ucdavis/fiehnlab/mona/backend/core/persistence/rest/server/controller/spectrum/SpectrumRestControllerSecurityTest.scala
@@ -192,5 +192,26 @@ class SpectrumRestControllerSecurityTest extends AbstractSpringControllerTest wi
         }
       }
     }
+
+    /**
+      * These depend on /error being excluded from the security chain in RestServerConfig. Spring
+      * re-dispatches an error to /error and Spring Boot runs the chain on the ERROR dispatch as well,
+      * where JWTAuthenticationFilter answers 401 for a request without an authorization header. Since
+      * the open GET endpoints never carry one, every status below used to reach the caller as an empty
+      * 401 instead of its own
+      */
+    "errors raised on the openly accessible endpoints" should {
+
+      "keep a bad request status rather than report an authentication failure" in {
+        given().contentType("application/json; charset=UTF-8")
+          .queryParam("size", "abc")
+          .when().get("/spectra").`then`().statusCode(400)
+      }
+
+      "keep a not found status for an unmapped path below an open endpoint" in {
+        given().contentType("application/json; charset=UTF-8")
+          .when().get("/spectra/a/b/c").`then`().statusCode(404)
+      }
+    }
   }
 }

--- a/backend/services/download-scheduler/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/services/downloader/scheduler/upload/UploadJobListener.scala
+++ b/backend/services/download-scheduler/src/main/scala/edu/ucdavis/fiehnlab/mona/backend/services/downloader/scheduler/upload/UploadJobListener.scala
@@ -244,17 +244,19 @@ class UploadJobListener extends GenericMessageListener[UploadJobRequest] with La
 
   // Cheap first pass so the progress bar has a real denominator before the main parse loop starts
   private def countTotal(storedPath: String, format: String): Long = format match {
-    case "msp" => countOccurrences(storedPath, "Num Peaks")
-    case "mgf" => countOccurrences(storedPath, "BEGIN IONS")
+    case "msp" => countOccurrences(storedPath, """(?i)num\s?peaks\s*:""")
+    case "mgf" => countOccurrences(storedPath, """BEGIN IONS""")
     case "massbank" =>
-      val count = countOccurrences(storedPath, "PK$NUM_PEAK")
+      val count = countOccurrences(storedPath, """PK\$NUM_PEAK""")
       if (count > 1) 0L else count
     case _ => 0L
   }
 
-  /** Streams the file in bounded chunks rather than loading it whole, carrying a marker sized
-    * tail across chunk boundaries so an occurrence split across two chunks is still counted */
+  /** Streams the file in bounded chunks rather than loading it whole, carrying a short tail across
+    * chunk boundaries so an occurrence split across two chunks is still counted, resuming that tail
+    * after the last counted match so nothing is counted twice */
   private def countOccurrences(path: String, marker: String): Long = {
+    val pattern = marker.r
     val reader = Files.newBufferedReader(Paths.get(path), StandardCharsets.UTF_8)
     try {
       val buf = new Array[Char](1024 * 1024)
@@ -263,12 +265,13 @@ class UploadJobListener extends GenericMessageListener[UploadJobRequest] with La
       var n = reader.read(buf)
       while (n != -1) {
         val text = carryTail + new String(buf, 0, n)
-        var idx = text.indexOf(marker)
-        while (idx != -1) {
+        var lastEnd = 0
+        pattern.findAllMatchIn(text).foreach { m =>
           count += 1
-          idx = text.indexOf(marker, idx + 1)
+          lastEnd = m.end
         }
-        carryTail = if (text.length >= marker.length) text.substring(text.length - marker.length + 1) else text
+        // 31 chars comfortably exceeds the longest marker match
+        carryTail = text.substring(math.max(text.length - 31, lastEnd))
         n = reader.read(buf)
       }
       count

--- a/scripts/sql/000_metadata_btree_indexes.sql
+++ b/scripts/sql/000_metadata_btree_indexes.sql
@@ -1,0 +1,15 @@
+-- Speeds up the very common "name AND value" metadata filter, e.g. a search for
+-- metaData.name:'ion mode' and metaData.value:'positive'.
+-- InChI rows are skipped because those values are long enough to bloat the index
+CREATE INDEX CONCURRENTLY IF NOT EXISTS metadata_name_value_idx
+    ON metadata (name, value)
+    WHERE name != 'InChI';
+
+-- Speeds up compound classification searches, which look for a value among the relatively
+-- few metadata rows that belong to a classification
+CREATE INDEX CONCURRENTLY IF NOT EXISTS metadata_classification_value_idx
+    ON metadata (value)
+    WHERE compound_classification_id IS NOT NULL;
+
+-- Refresh the planner's statistics so it starts using the new indexes right away
+ANALYZE metadata;

--- a/scripts/sql/001_trgm_search_indexes.sql
+++ b/scripts/sql/001_trgm_search_indexes.sql
@@ -1,0 +1,28 @@
+-- Trigram indexes for substring search.
+-- Terms shorter than 3 characters cannot use a trigram index, so the API rejects them
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Session only setting that makes the builds below considerably faster.
+-- It disappears when the psql session ends, so there is nothing to undo
+SET maintenance_work_mem = '2GB';
+
+-- Both of these back the quick search box (GET /rest/spectra/keyword), which looks for the
+-- term in metadata values and compound names.
+-- metadata is by far the largest table, expect minutes to tens of minutes on production
+CREATE INDEX CONCURRENTLY IF NOT EXISTS metadata_value_trgm_idx
+    ON metadata USING gin (value gin_trgm_ops);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS name_name_trgm_idx
+    ON name USING gin (name gin_trgm_ops);
+
+-- Partial SPLASH searches do not use the quick search endpoint. They go through the normal
+-- search API as splash.splash~'*term*', which is a single table predicate, so the planner can
+-- still use this index
+CREATE INDEX CONCURRENTLY IF NOT EXISTS splash_splash_trgm_idx
+    ON splash USING gin (splash gin_trgm_ops);
+
+-- Refresh the planner's statistics so it starts using the new indexes right away
+ANALYZE metadata;
+ANALYZE name;
+ANALYZE splash;

--- a/scripts/sql/002_extended_statistics.sql
+++ b/scripts/sql/002_extended_statistics.sql
@@ -1,0 +1,7 @@
+-- Teaches Postgres that metadata.name and metadata.value are correlated.
+
+CREATE STATISTICS IF NOT EXISTS metadata_name_value_stats (dependencies, ndistinct)
+    ON name, value FROM metadata;
+
+-- Populate the new statistics now rather than waiting for the next autovacuum
+ANALYZE metadata;

--- a/scripts/sql/README.md
+++ b/scripts/sql/README.md
@@ -1,0 +1,50 @@
+# Database Index Scripts
+
+Hibernate (`ddl-auto: update`) manages tables, columns and foreign key constraints, but never
+indexes, and Postgres does not index foreign key columns on its own. Without indexes every join
+and cascade delete degrades to a sequential scan.
+
+MoNA DB Indexes come from two places:
+
+- **Automatic:** `persistence-server` runs `core/persistence/postgresql/.../queries/spectrum_fields.sql`
+  on every startup (profile `mona.persistence.init`, `spring.sql.init.mode: always`). It creates the
+  foreign key indexes, `metadata_name_idx` and a few small lookup indexes. Nothing to do.
+- **Manual:** the scripts here. Not wired into the app, so each database (local, dev, prod) needs
+  them run against it by hand. This directory is the source of truth for that set.
+
+| Script | Contents |
+|---|---|
+| `000_metadata_btree_indexes.sql` | Partial b-trees on `metadata`: `(name, value)` for combined name/value filters, `(value)` for classification lookups |
+| `001_trgm_search_indexes.sql` | `pg_trgm` plus GIN trigram indexes for the quick search box (`/rest/spectra/keyword`) and partial SPLASH searches |
+| `002_extended_statistics.sql` | Multi column statistics on `metadata(name, value)`, fixing bad nested loop plans |
+
+## Applying
+
+Every statement is idempotent (`IF NOT EXISTS`), so re-running is always safe. Order does not
+matter. psql runs statements in autocommit, which is what `CONCURRENTLY` requires, so do **not**
+wrap these in `BEGIN`/`COMMIT`.
+
+```bash
+docker exec -i <postgres-container> psql -U $MONA_USER -d mona -v ON_ERROR_STOP=1 < scripts/sql/001_trgm_search_indexes.sql
+```
+
+On production, copy to gose and run it inside the postgres container under tmux or
+`docker exec -d` so a dropped SSH connection cannot kill the build. Watch progress from another
+session with `SELECT pid, phase, blocks_done, blocks_total FROM pg_stat_progress_create_index;`.
+
+Only `001` is slow; the GIN index on `metadata.value` takes minutes to tens of minutes.
+`CONCURRENTLY` does *not* block reads or writes. `002` should finish in seconds at any table size.
+
+## Verifying
+
+```sql
+SELECT indexname FROM pg_indexes WHERE indexname IN ('metadata_name_value_idx',
+  'metadata_classification_value_idx', 'metadata_value_trgm_idx', 'name_name_trgm_idx',
+  'splash_splash_trgm_idx');                              -- expect all 5
+SELECT stxname FROM pg_statistic_ext;                     -- expect metadata_name_value_stats
+SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;   -- expect nothing
+```
+
+The last query matters most: a failed `CONCURRENTLY` build leaves an INVALID index that is never
+used for queries but still slows every write, and since `IF NOT EXISTS` matches by *name only*, a
+re-run silently skips it. `DROP INDEX` anything reported, then re-run.


### PR DESCRIPTION
The curation queue would stop receiving messages if the rabbitmq container was restarted. Fixed by switching from on startup init to bean.

Also adds sql scripts for index creation in case of lost db.